### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/PythonToModelica/setup.py
+++ b/PythonToModelica/setup.py
@@ -27,5 +27,5 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.9',
 )


### PR DESCRIPTION
Actions now use Ubuntu 24.04 with python >= 3.9.*
https://github.com/actions/runner-images/issues/10636