### PR TITLE
Fixed warnings are errors when checking with Dymola.

### DIFF
--- a/NeuralNetwork/Examples/Utilities/NARX_Network.mo
+++ b/NeuralNetwork/Examples/Utilities/NARX_Network.mo
@@ -1,9 +1,10 @@
 within NeuralNetwork.Examples.Utilities;
-
 block NARX_Network
   // This represents a three layer neural network with a given time delay
 
-  extends NeuralNetwork.Networks.Interfaces.Network(u = layer_scale.u, y = layer_3.y);
+  extends NeuralNetwork.Networks.Interfaces.Network(
+    redeclare Modelica.Blocks.Interfaces.RealInput u[size(layer_1.u,1)],
+    redeclare Modelica.Blocks.Interfaces.RealOutput y[size(layer_3.y,1)]);
 
   NeuralNetwork.Layer.Preprocessing.Scale layer_scale(
     min = {
@@ -106,6 +107,9 @@ block NARX_Network
     redeclare function f = NeuralNetwork.ActivationFunctions.Id
    ) annotation(Placement(transformation(origin = {92, 0}, extent = {{-30, -30}, {30, 30}})));
 equation
+  connect( u, layer_scale.u);
+  connect( layer_3.y, y);
+
   connect(layer_scale.y, layer_1.u) annotation(
     Line(points = {{-74, 0}, {-52, 0}}, color = {0, 0, 127}, thickness = 0.5));
   connect(layer_1.y, layer_2.u) annotation(

--- a/NeuralNetwork/Examples/Utilities/SimpleNetwork.mo
+++ b/NeuralNetwork/Examples/Utilities/SimpleNetwork.mo
@@ -1,7 +1,6 @@
 within NeuralNetwork.Examples.Utilities;
-
 block SimpleNetwork "Neural Network approximating y = u*u + 0.5*u - 2.0 on interval [-1,1]"
-  extends NeuralNetwork.Networks.Interfaces.SISO(final u = inputLayer.u[1], final y = outputLayer.y[1]);
+  extends NeuralNetwork.Networks.Interfaces.SISO;
   Layer.Dense inputLayer(
     weights = layer_1_weights,
     bias = layer_1_bias,
@@ -20,6 +19,9 @@ block SimpleNetwork "Neural Network approximating y = u*u + 0.5*u - 2.0 on inter
   parameter Real[1,2] layer_2_weights = {{-4.513856227908402, 2.4932885356708683}};
   parameter Real[1] layer_2_bias = {3.897109323824147};
 equation
+  connect( u, inputLayer.u[1]);
+  connect( outputLayer.y[1], y);
+
   connect(inputLayer.y, outputLayer.u) annotation(
     Line(points = {{-48, 0}, {30, 0}}, color = {0, 0, 127}, thickness = 0.5));
   annotation(

--- a/NeuralNetwork/Layer/Interfaces/Layer.mo
+++ b/NeuralNetwork/Layer/Interfaces/Layer.mo
@@ -1,6 +1,5 @@
 within NeuralNetwork.Layer.Interfaces;
-
-partial model Layer
+partial block Layer
   // Topology of the neural network
   parameter Integer numInputs   "Specification of the inputs of the layer";
   parameter Integer numNeurons  "Number of neurons in the layer";


### PR DESCRIPTION
The following changes are based on test in Dymola. The items marked WARNING do not prevent simulation, but the ones marked ERROR result in translation errors and therefore prohibit simulation in Dymola.

WARNING: Classes extending Layer are blocks; to extend a model in a block is invalid Modelica => changed Layer type from model to block.

ERROR: The example networks connect in- and outputs with layers via component modification. This in invalid Modelica => changed to proper connect equations.

ERROR: The NARX_Network example leverages on propagating sizes via the connector. Again, this is not supported by the Modelica specification => sizes are now provided via redeclaration of the in- and outputs with size information. In general, the current library design for modeling sizes breaks with MSL design, where MIMO interfaces must have size parameters that are used to properly set the sizes. This is a rather big design issue that needs rethinking how to model the sizes proper.