### PR TITLE
Update openmodelica-library-testing-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
           omc-diff: true
 
       - name: openmodelica-library-testing
-        uses: OpenModelica/openmodelica-library-testing-action@v0.2.0
+        uses: OpenModelica/openmodelica-library-testing-action@v0.2
         with:
           library: NeuralNetwork
           library-version: '2.1.0'


### PR DESCRIPTION
## Issue

`openmodelica-library-testing-action@v0.2.0` broke because of an update of OMPython (v3.6 ==> v4.0.0).

```bash
Run OpenModelica/openmodelica-library-testing-action@v0.2.0
conf-NeuralNetwork.json:
[
  {
    "library": "NeuralNetwork",
    "libraryVersion": "2.1.0",
    "referenceFileExtension": "csv",
    "referenceFileNameDelimiter": ".",
    "referenceFiles": "/home/runner/work/NeuralNetwork/NeuralNetwork/ReferenceFiles",
    "loadFileCommands": [
      "loadFile(\"/home/runner/work/NeuralNetwork/NeuralNetwork/NeuralNetwork/package.mo\")"
    ]
  }
]
Error: Error executing Python script test.py
Command failed: python test.py --verbose --branch=stable --noclean  configs/conf-NeuralNetwork.json

Error: Command failed: python test.py --verbose --branch=stable --noclean  configs/conf-NeuralNetwork.json
```

## Changes

- openmodelica-library-testing-action@v0.2.1 was released and tag `v0.2` updated to point to it.
- Use `v0.2` tag in CI.

